### PR TITLE
Speed up session initialization with lazy loading

### DIFF
--- a/1password-op.plugin.zsh
+++ b/1password-op.plugin.zsh
@@ -15,17 +15,29 @@
 #    limitations under the License.
 
 if (( $+commands[op] )); then
-  if ! $(command -v _op &> /dev/null) ; then
-    # Set up a shim function so that until we actually use the 'op' command,
-    # don't bother to load its completions until the first time we actually
-    # use it
-    op() {
-      # Now that we're running 'op', load its completions
-      eval "$(op completion zsh)"; compdef _op op
-      # We can get rid of the shim and execute 'op' directly from now on
-      unfunction "$0"
-      # Execute 'op' binary
-      $0 "$@"
-    }
-  fi
+  OP_COMPLETIONS_D="${0:A:h}/completions"
+  # Set up a shim function so that until we actually use the 'op' command,
+  # don't bother to load its completions until the first time we actually
+  # use it
+  op() {
+    # If the completion file is more than a day old, scrub it and
+    # regenerate it - if op was updated, it might have changed the
+    # completion function.
+    #
+    # Do this only on first use of op so we don't slow down every session
+    # start - user may not always use op in a given session
+    find "$OP_COMPLETIONS_D/_op.zsh"  -newermt "24 hours ago" -delete
+    if [[ ! -f "$OP_COMPLETIONS_D/_op.zsh" ]]; then
+      op completion zsh 2> /dev/null > "$OP_COMPLETIONS_D/_op.zsh"
+    fi
+    # Add completions to the FPATH
+    typeset -TUx FPATH fpath
+    fpath=("$OP_COMPLETIONS_D" $fpath)
+
+    # We can get rid of the shim and execute 'op' directly from now on
+    # in this session.
+    unfunction "$0"
+    # Now that completions are ready, execute 'op' binary
+    $0 "$@"
+  }
 fi

--- a/1password-op.plugin.zsh
+++ b/1password-op.plugin.zsh
@@ -16,6 +16,8 @@
 
 if (( $+commands[op] )); then
   OP_COMPLETIONS_D="${0:A:h}/completions"
+  OP_COMPLETIONS_REFRESH_TIME="${OP_COMPLETIONS_REFRESH_TIME:-+5d}"
+
   # Set up a shim function so that until we actually use the 'op' command,
   # don't bother to load its completions until the first time we actually
   # use it
@@ -26,7 +28,8 @@ if (( $+commands[op] )); then
     #
     # Do this only on first use of op so we don't slow down every session
     # start - user may not always use op in a given session
-    find "$OP_COMPLETIONS_D/_op.zsh"  -newermt "24 hours ago" -delete
+    mkdir -p "$OP_COMPLETIONS_D"
+    find "$OP_COMPLETIONS_D" -name _op.zsh -ctime "${OP_COMPLETIONS_REFRESH_TIME}" -delete
     if [[ ! -f "$OP_COMPLETIONS_D/_op.zsh" ]]; then
       op completion zsh 2> /dev/null > "$OP_COMPLETIONS_D/_op.zsh"
     fi
@@ -36,7 +39,7 @@ if (( $+commands[op] )); then
 
     # We can get rid of the shim and execute 'op' directly from now on
     # in this session.
-    unfunction "$0"
+    unset -f op
     # Now that completions are ready, execute 'op' binary
     $0 "$@"
   }

--- a/1password-op.plugin.zsh
+++ b/1password-op.plugin.zsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 #
-#    Copyright 2022 Joe Block <jpb@unixorn.net>
+#    Copyright 2022-2023 Joe Block <jpb@unixorn.net>
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -16,6 +16,16 @@
 
 if (( $+commands[op] )); then
   if ! $(command -v _op &> /dev/null) ; then
-    eval "$(op completion zsh)"; compdef _op op
+    # Set up a shim function so that until we actually use the 'op' command,
+    # don't bother to load its completions until the first time we actually
+    # use it
+    op() {
+      # Now that we're running 'op', load its completions
+      eval "$(op completion zsh)"; compdef _op op
+      # We can get rid of the shim and execute 'op' directly from now on
+      unfunction "$0"
+      # Execute 'op' binary
+      $0 "$@"
+    }
   fi
 fi

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 
 This plugin loads the completions for `op` and its subcommands if it finds `op` in your `$PATH`. It has only been tested on `op` version 2, but should work with version 1 as well.
 
+The plugin does lazy loading of the `op` completions, and updates them every 5 days by default. If you want a different interval, set `OP_COMPLETIONS_REFRESH_TIME` using standard `find` time syntax - to set it to replace the completions file every 3 days, for example, you'd set it to `+3d`.
+
 ## Installation
 
 ### [Oh-My-Zsh](http://ohmyz.sh/)


### PR DESCRIPTION
Only load the tab completions for `op` when we actually run `op`.